### PR TITLE
Updated to allow for command line args to be passed in

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-fpm "0.2.2"
+(defproject lein-fpm "0.2.3"
   :description "A Leiningen plugin for generating minimalist packages using fpm."
   :url "http://github.com/bts/lein-fpm"
   :license {:name "MIT License"

--- a/src/leiningen/fpm.clj
+++ b/src/leiningen/fpm.clj
@@ -55,8 +55,10 @@
   [project]
   (let [jar-path (jar-destination-path project)
         opts (:jvm-opts project)
-        opts-string (when opts (str " " (string/join " " opts)))]
-    (string/trimr (str "java" opts-string " -jar " jar-path))))
+        init-string (if (not (empty? opts))
+                      (str "java " (string/join " " opts) " -jar")  
+                      "java -jar")]
+    (string/join " " [init-string jar-path "$@"])))
 
 (defn wrapper-binary
   "Writes a wrapper binary to :target-path/bin and returns its path."


### PR DESCRIPTION
Now the wrapper script correctly accepts `$@` and allows for passing of arbitrary CLI options for the given jarfile. Also cleaned up the extra space in between `java  -jar` that was being placed because `opts` was always considered true as an empty list `[]`.
